### PR TITLE
Show in LinearCombinationsTest the continuous variables with linear combinations

### DIFF
--- a/mercury/robust/data_tests.py
+++ b/mercury/robust/data_tests.py
@@ -134,7 +134,14 @@ class LinearCombinationsTest(RobustDataTest):
             )
 
         if lin_combinations is not None:
-            raise FailedTestError("Test failed. Linear combinations for continuous features were encountered.")
+            # Create message with the linear combinations found
+            lin_combinations = np.around(lin_combinations, decimals=5)
+            lin_combs_found = []
+            for i in range(lin_combinations.shape[0]):
+                lin_comb_idx = np.where(lin_combinations[i] != 0)[0]
+                lin_comb_cols = self.base_dataset.loc[:, numeric_feats].columns[lin_comb_idx].tolist()
+                lin_combs_found.append(lin_comb_cols)
+            raise FailedTestError(f"Test failed. Linear combinations for continuous features were encountered: {lin_combs_found}.")
 
         individually_redundant = CategoryStruct.individually_redundant(self.base_dataset, current_schema.categorical_feats)
         if len(individually_redundant) > 0:

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -857,4 +857,20 @@ def test_no_duplicated_test():
     with pytest.raises(FailedTestError):
         test.run()
 
+def test_lin_combinations_cont():
 
+    df = pd.DataFrame()
+    df["f1"] = np.random.uniform(size=100)
+    df["f2"] = df["f1"] * 2
+    df["f3"] = np.random.uniform(size=100)
+    df["f4"] = df["f1"] + df["f2"]
+    df["f5"] = np.random.uniform(size=100)
+
+    df["f6"] = np.random.uniform(size=100)
+    df["f7"] = df["f6"] * 3
+    df["f8"] = df["f6"] * 0.1
+
+    schma_reference = DataSchema().generate(df).calculate_statistics()
+    linear_comb_test = LinearCombinationsTest(df, dataset_schema=schma_reference)
+    with pytest.raises(FailedTestError, match="'f1', 'f2'"):
+        linear_comb_test.run()


### PR DESCRIPTION
Currently, when the LinearCombinations fails because it finds linear combinations in continuous variables it doesn't show which variables contain the linear combinations. This PR has the modifications to show which are these linear combinations.